### PR TITLE
Mount the m2 repository

### DIFF
--- a/cli/flows-cli.sh
+++ b/cli/flows-cli.sh
@@ -78,10 +78,12 @@ if ! is_absolute_path "${PATH_TO_SOURCE_CODE}" ; then
   exit 1
 fi
 
-if [ -z "${PATH_TO_M2_REPOSITORY:-}" ]; then
-  echo "Note: The environment variable PATH_TO_M2_REPOSITORY will be set to."
-  export PATH_TO_M2_REPOSITORY=$(eval echo "~/.m2/repository")
-  echo $PATH_TO_M2_REPOSITORY
+DEFAULT_M2_FOLDER="$HOME/.m2"
+if [ -z "${PIIANO_CS_M2_FOLDER:-}" ]; then
+  # if the user not deliver is own m2 folder - bind it to the default m2 folder
+  echo "Note: The environment variable PIIANO_CS_M2_FOLDER is not set"
+  mkdir -p "$DEFAULT_M2_FOLDER"
+  export PIIANO_CS_M2_FOLDER=$DEFAULT_M2_FOLDER
 fi
 
 # Get an access token.
@@ -143,6 +145,6 @@ docker run ${ADDTTY} --rm --pull=always --name piiano-flows  \
     -e "PIIANO_CS_USER_ID=${PIIANO_CS_USER_ID}" \
     --env-file <(env | grep PIIANO_CS) \
     -v "${PATH_TO_SOURCE_CODE}:/source" \
-    -v "${PATH_TO_M2_REPOSITORY}:/~/.m2/repository" \
+    -v "${PIIANO_CS_M2_FOLDER}:/root/.m2" \
     -p "${PORT}:3002" \
     ${PIIANO_CS_IMAGE} ${EXTRA_TEST_PARAMS[@]:-}

--- a/cli/flows-cli.sh
+++ b/cli/flows-cli.sh
@@ -78,13 +78,11 @@ if ! is_absolute_path "${PATH_TO_SOURCE_CODE}" ; then
   exit 1
 fi
 
-DEFAULT_M2_FOLDER="$HOME/.m2"
-if [ -z "${PIIANO_CS_M2_FOLDER:-}" ]; then
-  # if the user not deliver is own m2 folder - bind it to the default m2 folder
-  echo "Note: The environment variable PIIANO_CS_M2_FOLDER is not set"
-  mkdir -p "$DEFAULT_M2_FOLDER"
-  export PIIANO_CS_M2_FOLDER=$DEFAULT_M2_FOLDER
+export PIIANO_CS_M2_FOLDER=${PIIANO_CS_M2_FOLDER:-"$HOME/.m2"}
+if [ ! -d ${PIIANO_CS_M2_FOLDER} ] ; then
+   echo "Warning: creating folder ${PIIANO_CS_M2_FOLDER}"
 fi
+mkdir -p ${PIIANO_CS_M2_FOLDER}
 
 # Get an access token.
 echo "[ ] Getting access token..."

--- a/cli/flows-cli.sh
+++ b/cli/flows-cli.sh
@@ -78,6 +78,12 @@ if ! is_absolute_path "${PATH_TO_SOURCE_CODE}" ; then
   exit 1
 fi
 
+if [ -z "${PATH_TO_M2_REPOSITORY:-}" ]; then
+  echo "Note: The environment variable PATH_TO_M2_REPOSITORY will be set to."
+  export PATH_TO_M2_REPOSITORY=$(eval echo "~/.m2/repository")
+  echo $PATH_TO_M2_REPOSITORY
+fi
+
 # Get an access token.
 echo "[ ] Getting access token..."
 ACCESS_TOKEN=$(curl --silent --fail --location -X POST -H 'Content-Type: application/json' -d "{\"clientId\": \"${PIIANO_CLIENT_ID}\",\"secret\": \"${PIIANO_CLIENT_SECRET}\"}" https://auth.scanner.piiano.io/identity/resources/auth/v1/api-token | jq -r '.accessToken')
@@ -137,5 +143,6 @@ docker run ${ADDTTY} --rm --pull=always --name piiano-flows  \
     -e "PIIANO_CS_USER_ID=${PIIANO_CS_USER_ID}" \
     --env-file <(env | grep PIIANO_CS) \
     -v "${PATH_TO_SOURCE_CODE}:/source" \
+    -v "${PATH_TO_M2_REPOSITORY}:/~/.m2/repository" \
     -p "${PORT}:3002" \
     ${PIIANO_CS_IMAGE} ${EXTRA_TEST_PARAMS[@]:-}


### PR DESCRIPTION
- The user can bring his own m2 repository and it will be mounted to container m2 repository
- If he does not provide - mount his m2 repository to the container repository. 
      - If it does not exist - the script will create it for him
      - It will allow to reuse of the deps between scans on the same repository (full), and even partially reuse for scanning different repository  