### PR TITLE
fix: getting user-id

### DIFF
--- a/cli/flows-cli.sh
+++ b/cli/flows-cli.sh
@@ -126,7 +126,7 @@ echo "[ ] Getting access token..."
 ACCESS_TOKEN=$(curl --silent --fail --location -X POST -H 'Content-Type: application/json' -d "{\"clientId\": \"${PIIANO_CLIENT_ID}\",\"secret\": \"${PIIANO_CLIENT_SECRET}\"}" https://auth.scanner.piiano.io/identity/resources/auth/v1/api-token | jq -r '.accessToken')
 
 echo "[ ] Obtaining user ID..."
-PIIANO_CS_USER_ID=$(curl --silent --fail -H 'Content-Type: application/json' -H "Authorization: Bearer ${ACCESS_TOKEN}" https://auth.scanner.piiano.io/identity/resources/users/v2/me | jq -r '.sub')
+PIIANO_CS_USER_ID=$(curl --silent --fail -H 'Content-Type: application/json' -H "Authorization: Bearer ${ACCESS_TOKEN}" https://auth.scanner.piiano.io/identity/resources/tenants/api-tokens/v1 | jq -r '.[0].createdByUserId')
 
 # Assume AWS role.
 echo "[ ] Getting AWS access..."


### PR DESCRIPTION
# Do not merge - Might be N/A

---

This is following a conversation I had with Frontegg which suggested to change the API from /me to /tenants/api-tokens/v1.

It is accompanied by adding the `fe.secure.read.tenantApiTokens` permission to the API role.